### PR TITLE
Change tags to category. 

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -51,13 +51,13 @@ Add the appropriate key(s) to your `config.ini`:
 OMDB_KEY=<omdb_key>
 ```
 
-`MOVIES_TAG`: The torrent in question needs to be tagged with this tag for the application to pick it up and parse it as a movie. If this tag is ommitted, it won't matter if an OMDB_KEY is added, it will be ignored. **Both `OMDB_KEY` and `MOVIES_TAG` are required for movie lookups. If either is ommitted (or the torrent passed in is missing this tag, then the [default posting](###-default-posting) method will be used**
+`MOVIES_CATEGORY`: The torrent in question needs to be tagged with this tag for the application to pick it up and parse it as a movie. If this tag is ommitted, it won't matter if an OMDB_KEY is added, it will be ignored. **Both `OMDB_KEY` and `MOVIES_TAG` are required for movie lookups. If either is ommitted (or the torrent passed in is missing this tag, then the [default posting](###-default-posting) method will be used**
 
-`TV_TAG`: The torrent in question needs to be tagged with this tag for the application to pick it up and parse it as a tv show.
+`TV_CATEGORY`: The torrent in question needs to be tagged with this tag for the application to pick it up and parse it as a tv show.
 
 ```
-MOVIES_TAG=<tag_name_for_movie_files>
-TV_TAG=<tag_name_for_tv_files>
+MOVIES_CATEGORY=<category_name_for_movie_files>
+TV_CATEGORY=<category_name_for_tv_files>
 ```
 
 **If any of these keys are missing for any particular file type, the parsing will be skipped and the [default posting](###-default-posting) option will be used**
@@ -91,7 +91,7 @@ cd <path_to_directory_where_exe_and_batch_file_are> //Example: cd C:\webhook-tor
 START webhook-torrent-reporter-win.exe %1 %2 %3 %4 // The %1-4 are very important and will pass the command line args from qbittorrent along to the webhook reporter
 ```
 
-Using qBittorrent as an example, we can configure the application to launch a program when a torrent completes downloading and pass along the required information via command line arguments. Download and extract the application to a folder where the running user will have access. Go into qBittorrent settings > Downloads > and enable `Run external program on torrent completion`. Inside the text box, point to the batch file and pass along the command line args: `<path_to_.bat_file> %G %N %Z %C`.
+Using qBittorrent as an example, we can configure the application to launch a program when a torrent completes downloading and pass along the required information via command line arguments. Download and extract the application to a folder where the running user will have access. Go into qBittorrent settings > Downloads > and enable `Run external program on torrent completion`. Inside the text box, point to the batch file and pass along the command line args: `<path_to_.bat_file> %L %N %Z %C`.
 
 **NOTE: The arguments _are_ case sensitive and the order is very important. The directory where <path_to_.bat_file> is should also contain your `config.ini`.**
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -13,7 +13,7 @@ const GENERIC_PAYLOAD = Boolean(process.env.USE_GENERIC_PAYLOAD);
 
 interface ScriptParams {
     webhook_url?: string;
-    tags: string[];
+    category: string;
     file_name: string;
     file_size_bytes: number;
     number_of_files: number;
@@ -21,13 +21,13 @@ interface ScriptParams {
 
 const executeScript = async (params: ScriptParams) => {
 
-    const { webhook_url, tags, file_name, file_size_bytes, number_of_files } = params;
+    const { webhook_url, category, file_name, file_size_bytes, number_of_files } = params;
 
     if (!webhook_url) return;
 
-    const movies: string | undefined = process.env.MOVIES_TAG;
-    const tv: string | undefined = process.env.TV_TAG;
-    const music: string | undefined = process.env.MUSIC_TAG;
+    const movies: string | undefined = process.env.MOVIES_CATEGORY;
+    const tv: string | undefined = process.env.TV_CATEGORY;
+    const music: string | undefined = process.env.MUSIC_CATEGORY;
 
     const report: TorrentReport = {
         fileName: file_name,
@@ -37,15 +37,15 @@ const executeScript = async (params: ScriptParams) => {
 
     let postData: WebhookMessageCreateOptions | GenericWebhookPayload | undefined; 
 
-    if (movies && tags.includes(movies)) {
+    if (movies && category === movies) {
         logger.info(`Found movie tag with file: ${report.fileName}`);
         const reportBuilder = new MovieReportEmbedBuilder(CLIENT, GENERIC_PAYLOAD);
         postData = await reportBuilder.constructMovieReportWebhookPayload(report);
-    } else if (tv && tags.includes(tv)) {
+    } else if (tv && category === tv) {
         logger.info(`Found tv tag with file: ${report.fileName}`);
         const reportBuilder = new TVReportEmbedBuilder(CLIENT, GENERIC_PAYLOAD);
         postData = await reportBuilder.constructTVReportWebhookPayload(report);
-    } else if (music && tags.includes(music)) {
+    } else if (music && category === music) {
         // TODO: Need to find a way to parse music torrents
         // to search an api
     } else {
@@ -64,7 +64,7 @@ const executeScript = async (params: ScriptParams) => {
 const args = process.argv;
 const scriptParams: ScriptParams = {
     webhook_url: process.env.WEBHOOK_URL,
-    tags: args[2].split(","),
+    category: args[2],
     file_name: args[3] as string,
     file_size_bytes: Number(args[4]),
     number_of_files: Number(args[5])
@@ -74,7 +74,7 @@ if (!scriptParams.webhook_url) {
     logger.error("No webhook url provided. There is no action this script can perform", () => {
         process.exit(1);
     });
-} else if (!scriptParams.tags || !scriptParams.file_name || !scriptParams.file_size_bytes || !scriptParams.number_of_files) {
+} else if (!scriptParams.category || !scriptParams.file_name || !scriptParams.file_size_bytes || !scriptParams.number_of_files) {
     logger.error("Missing required command line arguments. There is no action this script can perform", () => {
         process.exit(1);
     });

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webhook-torrent-reporter",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "An app that can be triggered with command line arguments to post to a webhook and report that files have been downloaded",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
Indexers in the *arr family cannot automatically tag torrents, but can assign categories. This switches all the logic to look for categories not tags.